### PR TITLE
go: add cross-compiling toolchains

### DIFF
--- a/builder/golang/go_1.0/Dockerfile
+++ b/builder/golang/go_1.0/Dockerfile
@@ -6,3 +6,5 @@ RUN wget http://go.googlecode.com/files/go1.0.3.linux-amd64.tar.gz --quiet && \
 			sudo tar -C /usr/local -xzf go1.0.3.linux-amd64.tar.gz && \
 			sudo chown -R ubuntu:ubuntu /usr/local/go && \
 			rm go1.0.3.linux-amd64.tar.gz
+RUN PATH=/usr/local/go/bin:$PATH GOPATH=/tmp/gopath /usr/local/go/bin/go get github.com/mitchellh/gox
+RUN PATH=/usr/local/go/bin:$PATH /tmp/gopath/bin/gox -build-toolchain

--- a/builder/golang/go_1.1/Dockerfile
+++ b/builder/golang/go_1.1/Dockerfile
@@ -6,3 +6,5 @@ RUN wget http://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz --quiet && \
 			sudo tar -C /usr/local -xzf go1.1.2.linux-amd64.tar.gz && \
 			sudo chown -R ubuntu:ubuntu /usr/local/go && \
 			rm go1.1.2.linux-amd64.tar.gz
+RUN PATH=/usr/local/go/bin:$PATH GOPATH=/tmp/gopath /usr/local/go/bin/go get github.com/mitchellh/gox
+RUN PATH=/usr/local/go/bin:$PATH /tmp/gopath/bin/gox -build-toolchain

--- a/builder/golang/go_1.2/Dockerfile
+++ b/builder/golang/go_1.2/Dockerfile
@@ -6,3 +6,5 @@ RUN wget http://go.googlecode.com/files/go1.2.linux-amd64.tar.gz --quiet && \
 			sudo tar -C /usr/local -xzf go1.2.linux-amd64.tar.gz && \
 			sudo chown -R ubuntu:ubuntu /usr/local/go && \
 			rm go1.2.linux-amd64.tar.gz
+RUN PATH=/usr/local/go/bin:$PATH GOPATH=/tmp/gopath /usr/local/go/bin/go get github.com/mitchellh/gox
+RUN PATH=/usr/local/go/bin:$PATH /tmp/gopath/bin/gox -build-toolchain

--- a/builder/golang/go_1.3/Dockerfile
+++ b/builder/golang/go_1.3/Dockerfile
@@ -6,3 +6,5 @@ RUN wget http://golang.org/dl/go1.3.linux-amd64.tar.gz --quiet && \
 			sudo tar -C /usr/local -xzf go1.3.linux-amd64.tar.gz && \
 			sudo chown -R ubuntu:ubuntu /usr/local/go && \
 			rm go1.3.linux-amd64.tar.gz
+RUN PATH=/usr/local/go/bin:$PATH GOPATH=/tmp/gopath /usr/local/go/bin/go get github.com/mitchellh/gox
+RUN PATH=/usr/local/go/bin:$PATH /tmp/gopath/bin/gox -build-toolchain


### PR DESCRIPTION
adds cross-compilation toolchains to go images

I've pushed clever/go:1.2 and clever/go:1.3 to the docker registry for now, will PR this on main drone as well
