### PR TITLE
Update mongo dockerfile definitions

### DIFF
--- a/database/mongodb/mongodb_2.4_clever/Dockerfile
+++ b/database/mongodb/mongodb_2.4_clever/Dockerfile
@@ -1,3 +1,4 @@
+# Used in tests and in production on the mongo-docker-pipeline machines
 FROM ubuntu:precise
 RUN apt-get -qq update && apt-get -y install wget                       && \
     wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.4.0.tgz && \

--- a/database/mongodb/mongodb_2.4_clever/Dockerfile
+++ b/database/mongodb/mongodb_2.4_clever/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:precise
+RUN apt-get -qq update && apt-get -y install wget                       && \
+    wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.4.0.tgz && \
+    tar xzf mongodb-linux-x86_64-2.4.0.tgz                              && \
+    install -t /usr/bin mongodb-linux-x86_64-2.4.0/bin/*                && \
+    mkdir -p /data/db /var/lib/mongodb/                                 && \
+    rm mongodb-linux-x86_64-2.4.0.tgz                                   && \
+    rm -rf mongodb-linux-x86_64-2.4.0
+EXPOSE 27017
+ENTRYPOINT ["usr/bin/mongod"]
+CMD ["--noprealloc", "--smallfiles", "--nojournal", "--replSet", "TailTest"]

--- a/database/mongodb/mongodb_2.4_clever/Dockerfile
+++ b/database/mongodb/mongodb_2.4_clever/Dockerfile
@@ -1,4 +1,5 @@
 # Used in tests and in production on the mongo-docker-pipeline machines
+# Published to mongo/clever:2.4
 FROM ubuntu:precise
 RUN apt-get -qq update && apt-get -y install wget                       && \
     wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.4.0.tgz && \

--- a/database/mongodb/mongodb_3.0/Dockerfile
+++ b/database/mongodb/mongodb_3.0/Dockerfile
@@ -1,4 +1,5 @@
 # Used in tests
+# Published to clever/mongo:3.0
 FROM ubuntu:precise
 RUN apt-get -qq update && apt-get -y install wget                       && \
     wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.9.tgz && \

--- a/database/mongodb/mongodb_3.0/Dockerfile
+++ b/database/mongodb/mongodb_3.0/Dockerfile
@@ -1,3 +1,4 @@
+# Used in tests
 FROM ubuntu:precise
 RUN apt-get -qq update && apt-get -y install wget                       && \
     wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.9.tgz && \
@@ -8,4 +9,4 @@ RUN apt-get -qq update && apt-get -y install wget                       && \
     rm -rf mongodb-linux-x86_64-3.0.9
 EXPOSE 27017
 ENTRYPOINT ["usr/bin/mongod"]
-CMD ["--noprealloc", "--storageEngine", "wiredTiger", "--replSet", "TailTest"]
+CMD ["--noprealloc", "--storageEngine", "wiredTiger"]

--- a/database/mongodb/mongodb_3.0/Dockerfile
+++ b/database/mongodb/mongodb_3.0/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:precise
 RUN apt-get -qq update && apt-get -y install wget                       && \
-    wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.7.tgz && \
-    tar xzf mongodb-linux-x86_64-3.0.7.tgz                              && \
-    install -t /usr/bin mongodb-linux-x86_64-3.0.7/bin/*                && \
+    wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.9.tgz && \
+    tar xzf mongodb-linux-x86_64-3.0.9.tgz                              && \
+    install -t /usr/bin mongodb-linux-x86_64-3.0.9/bin/*                && \
     mkdir -p /data/db /var/lib/mongodb/                                 && \
-    rm mongodb-linux-x86_64-3.0.7.tgz                                   && \
-    rm -rf mongodb-linux-x86_64-3.0.7
+    rm mongodb-linux-x86_64-3.0.9.tgz                                   && \
+    rm -rf mongodb-linux-x86_64-3.0.9
 EXPOSE 27017
 ENTRYPOINT ["usr/bin/mongod"]
-CMD ["--noprealloc", "--smallfiles"]
+CMD ["--noprealloc", "--storageEngine", "wiredTiger", "--replSet", "TailTest"]

--- a/database/mongodb/mongodb_3.0_repl_set/Dockerfile
+++ b/database/mongodb/mongodb_3.0_repl_set/Dockerfile
@@ -1,0 +1,12 @@
+# Used in tests that require mongo to be started in repl set mode
+FROM ubuntu:precise
+RUN apt-get -qq update && apt-get -y install wget                       && \
+    wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.9.tgz && \
+    tar xzf mongodb-linux-x86_64-3.0.9.tgz                              && \
+    install -t /usr/bin mongodb-linux-x86_64-3.0.9/bin/*                && \
+    mkdir -p /data/db /var/lib/mongodb/                                 && \
+    rm mongodb-linux-x86_64-3.0.9.tgz                                   && \
+    rm -rf mongodb-linux-x86_64-3.0.9
+EXPOSE 27017
+ENTRYPOINT ["usr/bin/mongod"]
+CMD ["--noprealloc", "--storageEngine", "wiredTiger", "--replSet", "TailTest"]

--- a/database/mongodb/mongodb_3.0_repl_set/Dockerfile
+++ b/database/mongodb/mongodb_3.0_repl_set/Dockerfile
@@ -1,4 +1,5 @@
 # Used in tests that require mongo to be started in repl set mode
+# Published to mongo-repl:3.0
 FROM ubuntu:precise
 RUN apt-get -qq update && apt-get -y install wget                       && \
     wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.0.9.tgz && \


### PR DESCRIPTION
This adds / modifies a few docker files:
1. It adds the 2.4 docker file used in production
2. It updates the 3.0 docker file used in tests to start with wired tiger
3. It adds a 3.0 docker file that's started with the `--replSet` flag for the few
tests that need that