### PR TITLE
add base image for node 5.7.0 (clever/drone-node:5.7.0)

### DIFF
--- a/builder/node/node_5.7.0/Dockerfile
+++ b/builder/node/node_5.7.0/Dockerfile
@@ -1,0 +1,8 @@
+# published as clever/drone-node:5.7.0
+FROM bradrydzewski/base
+
+WORKDIR /home/ubuntu
+USER ubuntu
+ADD nodejs.sh /etc/drone.d/
+
+RUN /bin/bash -c ". /home/ubuntu/nvm/nvm.sh && nvm install v5.7.0"

--- a/builder/node/node_5.7.0/nodejs.sh
+++ b/builder/node/node_5.7.0/nodejs.sh
@@ -1,0 +1,2 @@
+. /home/ubuntu/nvm/nvm.sh
+nvm use v5.7.0


### PR DESCRIPTION
Rather than running these steps within our builds, let's update to use a consistent base image.