### PR TITLE
Update to Go 1.6.2

### DIFF
--- a/builder/golang/go_1.6/Dockerfile
+++ b/builder/golang/go_1.6/Dockerfile
@@ -2,7 +2,7 @@ FROM bradrydzewski/base
 WORKDIR /home/ubuntu
 USER ubuntu
 ADD golang.sh /etc/drone.d/
-RUN wget https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz --quiet && \
-			sudo tar -C /usr/local -xzf go1.6.1.linux-amd64.tar.gz && \
+RUN wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz --quiet && \
+			sudo tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz && \
 			sudo chown -R ubuntu:ubuntu /usr/local/go && \
-			rm go1.6.1.linux-amd64.tar.gz
+			rm go1.6.2.linux-amd64.tar.gz


### PR DESCRIPTION
Announcement: https://groups.google.com/forum/#!msg/golang-announce/8FwSHbMTEjQ/2-IAqgSbLgAJ

> go1.6.2 (released 2016/04/20) includes fixes to the compiler, runtime, tools, documentation, and the mime/multipart, net/http, and sort packages. 