### PR TITLE
update to use security bug patched version

### DIFF
--- a/builder/golang/go_1.6/Dockerfile
+++ b/builder/golang/go_1.6/Dockerfile
@@ -2,7 +2,7 @@ FROM bradrydzewski/base
 WORKDIR /home/ubuntu
 USER ubuntu
 ADD golang.sh /etc/drone.d/
-RUN wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz --quiet && \
-			sudo tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz && \
+RUN wget https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz --quiet && \
+			sudo tar -C /usr/local -xzf go1.6.3.linux-amd64.tar.gz && \
 			sudo chown -R ubuntu:ubuntu /usr/local/go && \
-			rm go1.6.2.linux-amd64.tar.gz
+			rm go1.6.3.linux-amd64.tar.gz


### PR DESCRIPTION
see: https://groups.google.com/forum/#!topic/golang-nuts/kfzBGiAcxME

> A security-related issue was recently reported in Go's net/http/cgi
> package and net/http package when used in a CGI environment. Go 1.6.3
> and Go 1.7rc2 will contain a fix for this issue.

> Go versions 1.0-1.6.2 and 1.7rc1 are vulnerable to an input validation
> flaw in the CGI components resulting in the HTTP_PROXY environment
> variable being set by the incoming Proxy header. This environment
> variable was also used to set the outgoing proxy, enabling an attacker
> to insert a proxy into outgoing requests of a CGI program.
> This is CVE-2016-5386 and was addressed by this change:
> https://golang.org/cl/25010, tracked in this issue:
> https://golang.org/issue/16405