### PR TITLE
update node/npm version in base image

### DIFF
--- a/builder/base/rootfs/etc/drone.d/nodejs.sh
+++ b/builder/base/rootfs/etc/drone.d/nodejs.sh
@@ -1,2 +1,2 @@
 . /home/ubuntu/nvm/nvm.sh
-nvm use v0.10.22 > /dev/null
+nvm use 6 > /dev/null

--- a/builder/base/rootfs/etc/drone.d/rbenv.sh
+++ b/builder/base/rootfs/etc/drone.d/rbenv.sh
@@ -1,9 +1,9 @@
-export PATH="/home/ubuntu/.rbenv/bin:$PATH"
+#export PATH="/home/ubuntu/.rbenv/bin:$PATH"
 
 # set default env vars
-export RBENV_VERSION=2.0.0-p353
-export RAILS_ENV=${RAILS_ENV:-test}
+#export RBENV_VERSION=2.0.0-p353
+#export RAILS_ENV=${RAILS_ENV:-test}
 
 # initialize and set ruby version
-eval "$(rbenv init -)"
-rbenv global 2.0.0-p353
+#eval "$(rbenv init -)"
+#rbenv global 2.0.0-p353

--- a/builder/base/scripts/all.sh
+++ b/builder/base/scripts/all.sh
@@ -40,16 +40,16 @@ sudo apt-get -y install git git-core subversion mercurial bzr fossil xvfb socat
 # WARNING: ITEMS BELOW WILL CHANGE OVER TIME
 
 # install browsers
-./chromium.sh
-./firefox.sh
-./chrome.sh
-./phantomjs.sh
+#./chromium.sh
+#./firefox.sh
+#./chrome.sh
+#./phantomjs.sh
 
 # install base languages
-./openjdk.sh
+#./openjdk.sh
 ./python.sh
 ./nodejs.sh
-./ruby.sh
+#./ruby.sh
 ./golang.sh
 
 

--- a/builder/base/scripts/golang.sh
+++ b/builder/base/scripts/golang.sh
@@ -7,9 +7,9 @@ pushd /tmp
 sudo apt-get -y install pkg-config
 
 # download and install Go binaries
-wget https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz --quiet
-sudo tar -C /usr/lib -xzf go1.1.2.linux-amd64.tar.gz
-rm go1.1.2.linux-amd64.tar.gz
+wget https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz --quiet
+sudo tar -C /usr/lib -xzf go1.7.1.linux-amd64.tar.gz
+rm go1.7.1.linux-amd64.tar.gz
 
 # ubuntu user must have access to the go
 # standard library

--- a/builder/base/scripts/nodejs.sh
+++ b/builder/base/scripts/nodejs.sh
@@ -10,4 +10,4 @@
 
 git clone git://github.com/creationix/nvm.git /home/ubuntu/nvm
 . /home/ubuntu/nvm/nvm.sh
-nvm install v0.10.22
+nvm install 6

--- a/builder/golang/go_1.7/Dockerfile
+++ b/builder/golang/go_1.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM bradrydzewski/base
+FROM clever/drone-base
 WORKDIR /home/ubuntu
 USER ubuntu
 ADD golang.sh /etc/drone.d/


### PR DESCRIPTION
This updates the base image to include node v6 (w/ npm v3). I've published it as `clever/drone-base` in dockerhub.

It also updates the go 1.7 image to use this base image instead of `bradrydzewski/base`. Once this is published, go services that publish npm packages will no longer need to do an upgrade of npm in tests.

Tested locally:

```
vagrant@vagrant-ubuntu-trusty-64:~/go/src/github.com/Clever/images/builder/golang/go_1.7$ docker build -t drone-go17 .
...
vagrant@vagrant-ubuntu-trusty-64:~/go/src/github.com/Clever/images/builder/golang/go_1.7$ docker run -it drone-go17 /bin/bash
ubuntu@761ec5b32b01:~$ npm version
{ npm: '3.10.3',
  ares: '1.10.1-DEV',
  http_parser: '2.7.0',
  icu: '57.1',
  modules: '48',
  node: '6.7.0',
  openssl: '1.0.2j',
  uv: '1.9.1',
  v8: '5.1.281.83',
  zlib: '1.2.8' }
ubuntu@761ec5b32b01:~$ node --version
v6.7.0
```

Note that I also stripped some things out of the base image that were both failing to build successfully and (I think?) unused by our builds:
- ruby
- java
- browser stuff (chromium/firefox/chrome/phantomjs)