### PR TITLE
go 1.7: use bradrydzewski/base as base image

### DIFF
--- a/builder/golang/go_1.7/Dockerfile
+++ b/builder/golang/go_1.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM clever/drone-base
+FROM bradrydzewski/base
 WORKDIR /home/ubuntu
 USER ubuntu
 ADD golang.sh /etc/drone.d/


### PR DESCRIPTION
All other images, including Go versions, use `bradrydzewski/base` as the base image.